### PR TITLE
fix: Revert to the correct Speakeasy workspace value that got changed to an older value in the last release

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.733.2
 sources:
     Public:
         sourceNamespace: public
-        sourceRevisionDigest: sha256:d83ef5ac9496729e99e8dd53e6c32c33aed362e344f0ff3d65289c621eaa0c7f
-        sourceBlobDigest: sha256:97af000c32477103efc512a4c32234996c40c8d7704fd2699b510557aaf8abd3
+        sourceRevisionDigest: sha256:c235a8653a8473f60169d55f25bd0ae93a41f0dd849469c12466242260cff70d
+        sourceBlobDigest: sha256:bc4ed9649195b737a4f5dd51b675528269311f8c760b06e311dac40921116c69
         tags:
             - latest
             - ea
@@ -11,18 +11,24 @@ targets:
     public-csharp:
         source: Public
         sourceNamespace: public
-        sourceRevisionDigest: sha256:d83ef5ac9496729e99e8dd53e6c32c33aed362e344f0ff3d65289c621eaa0c7f
-        sourceBlobDigest: sha256:97af000c32477103efc512a4c32234996c40c8d7704fd2699b510557aaf8abd3
+        sourceRevisionDigest: sha256:c235a8653a8473f60169d55f25bd0ae93a41f0dd849469c12466242260cff70d
+        sourceBlobDigest: sha256:bc4ed9649195b737a4f5dd51b675528269311f8c760b06e311dac40921116c69
+        codeSamplesNamespace: csharp
+        codeSamplesRevisionDigest: sha256:47a5168914e4fc4b9c2db7fb36d8fba21db0565a325a7949a298ea7f4e3e6c7c
     public-java:
         source: Public
         sourceNamespace: public
-        sourceRevisionDigest: sha256:d83ef5ac9496729e99e8dd53e6c32c33aed362e344f0ff3d65289c621eaa0c7f
-        sourceBlobDigest: sha256:97af000c32477103efc512a4c32234996c40c8d7704fd2699b510557aaf8abd3
+        sourceRevisionDigest: sha256:c235a8653a8473f60169d55f25bd0ae93a41f0dd849469c12466242260cff70d
+        sourceBlobDigest: sha256:bc4ed9649195b737a4f5dd51b675528269311f8c760b06e311dac40921116c69
+        codeSamplesNamespace: java
+        codeSamplesRevisionDigest: sha256:ec3e45c31cb551fe060ff0aaf0c809bf6fe708e26358dc37c8c4af156f691f2f
     public-typescript:
         source: Public
         sourceNamespace: public
-        sourceRevisionDigest: sha256:d83ef5ac9496729e99e8dd53e6c32c33aed362e344f0ff3d65289c621eaa0c7f
-        sourceBlobDigest: sha256:97af000c32477103efc512a4c32234996c40c8d7704fd2699b510557aaf8abd3
+        sourceRevisionDigest: sha256:c235a8653a8473f60169d55f25bd0ae93a41f0dd849469c12466242260cff70d
+        sourceBlobDigest: sha256:bc4ed9649195b737a4f5dd51b675528269311f8c760b06e311dac40921116c69
+        codeSamplesNamespace: typescript
+        codeSamplesRevisionDigest: sha256:ce9559ed1251eff87cb29d5805f91305276429630fe1b9c91361c11007575663
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.733.2
@@ -37,7 +43,7 @@ workflow:
                 - location: ./overlays/description_overlay.yaml
                 - location: ./overlays/segments_error_response_overlay.yaml
             registry:
-                location: registry.speakeasyapi.dev/cvent/universal-api-platform/public
+                location: registry.speakeasyapi.dev/cvent/rest-sdks/public
     targets:
         public-csharp:
             target: csharp
@@ -48,7 +54,7 @@ workflow:
                     apiKey: $nuget_api_key
             codeSamples:
                 registry:
-                    location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-csharp-code-samples
+                    location: registry.speakeasyapi.dev/cvent/rest-sdks/csharp
                 labelOverride:
                     fixedValue: CSharp (SDK)
                 blocking: false
@@ -64,7 +70,7 @@ workflow:
                     gpgPassPhrase: $java_gpg_passphrase
             codeSamples:
                 registry:
-                    location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-java-code-samples
+                    location: registry.speakeasyapi.dev/cvent/rest-sdks/java
                 labelOverride:
                     fixedValue: Java (SDK)
                 blocking: false
@@ -77,7 +83,7 @@ workflow:
                     token: $npm_token
             codeSamples:
                 registry:
-                    location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-typescript-code-samples
+                    location: registry.speakeasyapi.dev/cvent/rest-sdks/typescript
                 labelOverride:
                     fixedValue: Typescript (SDK)
                 blocking: false

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -11,7 +11,7 @@ sources:
       - location: ./overlays/description_overlay.yaml
       - location: ./overlays/segments_error_response_overlay.yaml
     registry:
-      location: registry.speakeasyapi.dev/cvent/universal-api-platform/public
+      location: registry.speakeasyapi.dev/cvent/rest-sdks/public
 targets:
   public-csharp:
     target: csharp
@@ -22,7 +22,7 @@ targets:
         apiKey: $nuget_api_key
     codeSamples:
       registry:
-        location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-csharp-code-samples
+        location: registry.speakeasyapi.dev/cvent/rest-sdks/csharp
       labelOverride:
         fixedValue: CSharp (SDK)
       blocking: false
@@ -38,7 +38,7 @@ targets:
         gpgPassPhrase: $java_gpg_passphrase
     codeSamples:
       registry:
-        location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-java-code-samples
+        location: registry.speakeasyapi.dev/cvent/rest-sdks/java
       labelOverride:
         fixedValue: Java (SDK)
       blocking: false
@@ -51,7 +51,7 @@ targets:
         token: $npm_token
     codeSamples:
       registry:
-        location: registry.speakeasyapi.dev/cvent/universal-api-platform/public-typescript-code-samples
+        location: registry.speakeasyapi.dev/cvent/rest-sdks/typescript
       labelOverride:
         fixedValue: Typescript (SDK)
       blocking: false

--- a/packages/csharp/.speakeasy/gen.lock
+++ b/packages/csharp/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: ea
   speakeasyVersion: 1.733.2
   generationVersion: 2.845.11
-  releaseVersion: 1.0.9
-  configChecksum: 9475a8c3cd7b77632f6addf8cdf48cb1
+  releaseVersion: 1.0.10
+  configChecksum: 683f51af1c0c6aeb43e785fcfbac1e8b
   published: true
 persistentEdits:
   generation_id: c50843e4-e393-4964-8f45-57aa92ab8994
@@ -9246,7 +9246,7 @@ trackedFiles:
     pristine_git_object: 977cd7381c7598682830d6e4a64a85cb14130b98
   src/Cvent/SDK/Cvent.SDK.csproj:
     id: 7a55759bc2f0
-    last_write_checksum: sha1:812b8716ecb23435b80ed191e21fd18d366481c8
+    last_write_checksum: sha1:26c8b7ad067711aa7b4b56ebc9d88c2c041180d3
     pristine_git_object: 711013944bc0505858b0b7cf177f166071b47593
   src/Cvent/SDK/CventSDK.cs:
     id: f7e1ad22cd8f
@@ -18292,7 +18292,7 @@ trackedFiles:
     pristine_git_object: 58003eaf89fe1986cc662177f443175c4da22c63
   src/Cvent/SDK/SDKConfig.cs:
     id: 7ad7086454a8
-    last_write_checksum: sha1:33743dc3318e8f3a23b4306c256c1f932b3ff644
+    last_write_checksum: sha1:98d26f6cf1cc9e62f122d9aa5e79105f4cb1af33
     pristine_git_object: 796c23cd551fbe87f613d89d60ed25ac5fe0c54b
   src/Cvent/SDK/Seating.cs:
     id: 01c249fc2746
@@ -18348,7 +18348,7 @@ trackedFiles:
     pristine_git_object: a75f770b33edd25c0fa4d4a77ab523da12d269ba
   src/Cvent/SDK/Utils/Constants.cs:
     id: 231d94d8a5dc
-    last_write_checksum: sha1:a67244188f51ae878adab1a3a78838f75846735d
+    last_write_checksum: sha1:f08e14918702d22c2f3c9425e62b8c136c241385
     pristine_git_object: 0a54932893793a10e459afbc15920803cff3ed1e
   src/Cvent/SDK/Utils/CventSDKHttpClient.cs:
     id: 374fee4fdbaf

--- a/packages/csharp/.speakeasy/gen.yaml
+++ b/packages/csharp/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 csharp:
-  version: 1.0.9
+  version: 1.0.10
   additionalDependencies: []
   author: Cvent
   baseErrorName: CventSDKException

--- a/packages/csharp/src/Cvent/SDK/Cvent.SDK.csproj
+++ b/packages/csharp/src/Cvent/SDK/Cvent.SDK.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>Cvent.SDK</PackageId>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Cvent</Authors>
     <Copyright>Copyright (c) Cvent 2026</Copyright>

--- a/packages/csharp/src/Cvent/SDK/SDKConfig.cs
+++ b/packages/csharp/src/Cvent/SDK/SDKConfig.cs
@@ -46,7 +46,7 @@ namespace Cvent.SDK
             Client = client ?? new CventSDKHttpClient();
             ServerUrl = "";
             ServerIndex = 0;
-            UserAgent = "speakeasy-sdk/csharp 1.0.9 2.845.11 ea Cvent.SDK";
+            UserAgent = "speakeasy-sdk/csharp 1.0.10 2.845.11 ea Cvent.SDK";
             SecuritySource = null;
             Hooks = new SDKHooks();
             RetryConfig = null;

--- a/packages/csharp/src/Cvent/SDK/Utils/Constants.cs
+++ b/packages/csharp/src/Cvent/SDK/Utils/Constants.cs
@@ -22,7 +22,7 @@ namespace Cvent.SDK.Utils
         /// <summary>
         /// The version of the SDK.
         /// </summary>
-        public const string SdkVersion = "1.0.9";
+        public const string SdkVersion = "1.0.10";
 
         /// <summary>
         /// The version of the SDK generator used to create this SDK.

--- a/packages/java/.speakeasy/gen.lock
+++ b/packages/java/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: ea
   speakeasyVersion: 1.733.2
   generationVersion: 2.845.11
-  releaseVersion: 1.0.8
-  configChecksum: f4dbf4a91bbabf21b56329b9feb89b54
+  releaseVersion: 1.0.9
+  configChecksum: 3391801e154288f02adc1e3e8887832d
   published: true
 persistentEdits:
   generation_id: 6ad3309a-d2a1-4e74-a3ae-065e16d1999e
@@ -9172,7 +9172,7 @@ trackedFiles:
     pristine_git_object: cda742065b0bb30407900c4d39885b8db164b9b4
   gradle.properties:
     id: 2afbb999f001
-    last_write_checksum: sha1:e7067faca67a4ef4157e1235b16a872043dbef7d
+    last_write_checksum: sha1:0d67ebbe02b90c4ad830b9780e093bc29e06c7ed
     pristine_git_object: 6da141a8453a679109d12dba513b6d08b9e37fd5
   gradle/wrapper/gradle-wrapper.jar:
     id: ec27dae6e852
@@ -9540,7 +9540,7 @@ trackedFiles:
     pristine_git_object: bc111c9386302593f4ef2aa373156354a5d2b5e6
   src/main/java/com/cvent/SDKConfiguration.java:
     id: cdb9837839f5
-    last_write_checksum: sha1:8041dd6991edd31b8e23c608f536d801aa3759f1
+    last_write_checksum: sha1:c5fa05583ae0566e64300535b1bc898cb17227e3
     pristine_git_object: 4b98b23f51bc18bad5890089f44055b6187ed9f0
   src/main/java/com/cvent/Seating.java:
     id: 70583b24bb9b

--- a/packages/java/.speakeasy/gen.yaml
+++ b/packages/java/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 java:
-  version: 1.0.8
+  version: 1.0.9
   additionalDependencies: []
   additionalPlugins: []
   artifactID: sdk

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -41,7 +41,7 @@ The samples below show how a published SDK artifact is used:
 
 Gradle:
 ```groovy
-implementation 'com.cvent:sdk:1.0.8'
+implementation 'com.cvent:sdk:1.0.9'
 ```
 
 Maven:
@@ -49,7 +49,7 @@ Maven:
 <dependency>
     <groupId>com.cvent</groupId>
     <artifactId>sdk</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 </dependency>
 ```
 

--- a/packages/java/gradle.properties
+++ b/packages/java/gradle.properties
@@ -1,4 +1,4 @@
 groupId=com.cvent
 artifactId=sdk
-version=1.0.8
+version=1.0.9
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/packages/java/src/main/java/com/cvent/SDKConfiguration.java
+++ b/packages/java/src/main/java/com/cvent/SDKConfiguration.java
@@ -20,7 +20,7 @@ public class SDKConfiguration {
 
     private static final String LANGUAGE = "java";
     public static final String OPENAPI_DOC_VERSION = "ea";
-    public static final String SDK_VERSION = "1.0.8";
+    public static final String SDK_VERSION = "1.0.9";
     public static final String GEN_VERSION = "2.845.11";
     private static final String BASE_PACKAGE = "com.cvent";
     public static final String USER_AGENT = 

--- a/packages/typescript/.speakeasy/gen.lock
+++ b/packages/typescript/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: ea
   speakeasyVersion: 1.733.2
   generationVersion: 2.845.11
-  releaseVersion: 1.1.0
-  configChecksum: 5b58d68ee9c364a8f1c9f4c91fa09540
+  releaseVersion: 1.1.1
+  configChecksum: 07418aa8a0ba5ced2813e9f45781cce4
   repoURL: https://github.com/cvent/rest-sdks
   repoSubDirectory: packages/typescript
   published: true
@@ -8109,11 +8109,11 @@ trackedFiles:
     pristine_git_object: 80795a72645811f07559dbfd91e59131f127b3d4
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:7f7c1416439af350ff3c921eb1a445d9084bba16
+    last_write_checksum: sha1:a748fb817fc44c17f6e9159d27a10eb98b81ccb7
     pristine_git_object: 3f8c18265e80f8c46d349b3a7d92f1a61f1d2dc9
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:7b08bc5d518e205c0b860c19f3fbb90f34aa3e18
+    last_write_checksum: sha1:0de89e93ccedb446d5642d0ae8750d092746aa3e
     pristine_git_object: 3474c00ef1d014883367c7bbeca6cbe6e330ca41
   src/core.ts:
     id: f431fdbcd144
@@ -9847,7 +9847,7 @@ trackedFiles:
     pristine_git_object: 0aebd8b0a4867e35cb3348fc52921c3c0b4725b7
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:8d91fd936a2f126b666aee8629dbd03f0f298db8
+    last_write_checksum: sha1:7bf1c821388678febf449be650dea0675d2a6142
     pristine_git_object: 95847bcf50487c6ea615eb470cacdf861e9ba5e2
   src/lib/dlv.ts:
     id: b1988214835a

--- a/packages/typescript/.speakeasy/gen.yaml
+++ b/packages/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 typescript:
-  version: 1.1.0
+  version: 1.1.1
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/packages/typescript/jsr.json
+++ b/packages/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@cvent/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cvent/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Cvent",
   "files": [
     "dist/",

--- a/packages/typescript/src/lib/config.ts
+++ b/packages/typescript/src/lib/config.ts
@@ -66,7 +66,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "ea",
-  sdkVersion: "1.1.0",
+  sdkVersion: "1.1.1",
   genVersion: "2.845.11",
-  userAgent: "speakeasy-sdk/typescript 1.1.0 2.845.11 ea @cvent/sdk",
+  userAgent: "speakeasy-sdk/typescript 1.1.1 2.845.11 ea @cvent/sdk",
 } as const;


### PR DESCRIPTION
Revert to the correct Speakeasy workspace value that got changed to an older value in the last release