### PR TITLE
Cvent Java SDK v1.2.2 - Add configurable connect and call timeouts to the Java SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 target/
 .speakeasy/temp
 .idea/
+.DS_Store

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -18,6 +18,8 @@ targets:
         sourceNamespace: public
         sourceRevisionDigest: sha256:765122bb202784dc618ae38a775407692926450fa2e7b593e79b2e8ee8f7954a
         sourceBlobDigest: sha256:ddf0cc8274a74baa4e9a466166f6ce7d5a9098d82a657292c7e7491105e1e2c1
+        codeSamplesNamespace: java
+        codeSamplesRevisionDigest: sha256:e2c51ac5e03f77e5d416d217dcb03be5f0e4549662e36ad6eb117991b16b6d0d
     public-typescript:
         source: Public
         sourceNamespace: public

--- a/packages/java/.speakeasy/gen.lock
+++ b/packages/java/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: ea
   speakeasyVersion: 1.752.0
   generationVersion: 2.859.2
-  releaseVersion: 1.2.1
-  configChecksum: c7411a8257f8346c256207aae5728f86
+  releaseVersion: 1.2.2
+  configChecksum: 765981f6a1b0f7fb1ccd9033a3d85754
   published: true
 persistentEdits:
   generation_id: 6ad3309a-d2a1-4e74-a3ae-065e16d1999e
@@ -9181,7 +9181,7 @@ trackedFiles:
     pristine_git_object: cda742065b0bb30407900c4d39885b8db164b9b4
   gradle.properties:
     id: 2afbb999f001
-    last_write_checksum: sha1:2b5f9e7dc9b9ffcfa92f44228cf820544b4ee1c1
+    last_write_checksum: sha1:363f44f15a78e266a558dd10de2b0ea3f1a86f50
     pristine_git_object: 6da141a8453a679109d12dba513b6d08b9e37fd5
   gradle/wrapper/gradle-wrapper.jar:
     id: ec27dae6e852
@@ -9549,7 +9549,7 @@ trackedFiles:
     pristine_git_object: bc111c9386302593f4ef2aa373156354a5d2b5e6
   src/main/java/com/cvent/SDKConfiguration.java:
     id: cdb9837839f5
-    last_write_checksum: sha1:7cfbff6151d02098fbe0232ec439c66296524c57
+    last_write_checksum: sha1:97307546e8b11eebdbdcb8757cdadf6b59fd27dc
     pristine_git_object: 4b98b23f51bc18bad5890089f44055b6187ed9f0
   src/main/java/com/cvent/Seating.java:
     id: 70583b24bb9b

--- a/packages/java/.speakeasy/gen.yaml
+++ b/packages/java/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 java:
-  version: 1.2.1
+  version: 1.2.2
   additionalDependencies: []
   additionalPlugins: []
   artifactID: sdk

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -1470,7 +1470,7 @@ public class Application {
         // Create a custom HTTP client with hooks
         HTTPClient httpClient = new HTTPClient() {
             private final HTTPClient defaultClient = new SpeakeasyHTTPClient();
-            
+                   
             @Override
             public HttpResponse<InputStream> send(HttpRequest request) throws IOException, URISyntaxException, InterruptedException {
                 // Add custom header and timeout using Utils.copy()
@@ -1478,7 +1478,7 @@ public class Application {
                     .header("x-custom-header", "custom value")
                     .timeout(Duration.ofSeconds(30))
                     .build();
-                    
+
                 try {
                     HttpResponse<InputStream> response = defaultClient.send(modifiedRequest);
                     // Log successful response
@@ -1571,6 +1571,57 @@ public class Application {
 ```
 <!-- End Custom HTTP Client [http-client] -->
 
+## Configuring Timeouts
+
+The SDK applies two timeouts to every request by default:
+
+| Timeout | Default | Description |
+|---|---|---|
+| **Connect** | 10 seconds | Maximum time to establish a TCP connection to the Cvent API |
+| **Call** | 30 seconds | Maximum time for the entire request/response cycle (connect + send + receive) |
+
+Both can be overridden globally by calling `SDKHooks.configure()` **before** constructing the SDK instance:
+
+```java
+import com.cvent.CventSDK;
+import com.cvent.hooks.SDKHooks;
+import com.cvent.models.components.SchemeOAuth2ClientCredentials;
+import com.cvent.models.components.Security;
+import java.time.Duration;
+import java.util.List;
+
+public class Application {
+    public static void main(String[] args) {
+        // Override timeouts before building the SDK.
+        // Pass null for either value to keep its default.
+        SDKHooks.configure(
+            Duration.ofSeconds(5),    // connect timeout (default: 10s)
+            Duration.ofSeconds(60)    // call timeout    (default: 30s)
+        );
+
+        CventSDK sdk = CventSDK.builder()
+                .security(Security.builder()
+                        .oAuth2ClientCredentials(SchemeOAuth2ClientCredentials.builder()
+                                .clientID("<id>")
+                                .clientSecret("<value>")
+                                .tokenURL("https://api-platform.cvent.com/ea/oauth2/token")
+                                .scopes(List.of(System.getenv().getOrDefault("SCOPES", "")))
+                                .build())
+                        .build())
+                .build();
+    }
+}
+```
+
+For services with long-running operations (bulk imports, report generation, etc.), increase the call timeout accordingly:
+
+```java
+// Keep the default connect timeout, extend the call timeout to 5 minutes
+SDKHooks.configure(null, Duration.ofMinutes(5));
+```
+
+> **Note:** `SDKHooks.configure()` sets global JVM-wide state. If your application creates multiple SDK instances with different timeout requirements, call `configure()` again before each `build()` call with the appropriate values.
+
 <!-- Start Debugging [debug] -->
 ## Debugging
 
@@ -1593,7 +1644,7 @@ Received response: (GET http://localhost:35123/bearer#global) 200
 Response headers: {access-control-allow-credentials=[true], access-control-allow-origin=[*], connection=[keep-alive], content-length=[50], content-type=[application/json], date=[Wed, 09 Apr 2025 01:43:29 GMT], server=[gunicorn/19.9.0]}
 Response body:
 {
-  "authenticated": true, 
+  "authenticated": true,
   "token": "global"
 }
 ```

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -26,6 +26,7 @@ For more information about the API: [Cvent Developer Documentation](https://deve
   * [Error Handling](#error-handling)
   * [Server Selection](#server-selection)
   * [Custom HTTP Client](#custom-http-client)
+  * [Configuring Timeouts](#configuring-timeouts)
   * [Debugging](#debugging)
   * [License](#license)
   * [Jackson Configuration](#jackson-configuration)
@@ -43,7 +44,7 @@ The samples below show how a published SDK artifact is used:
 
 Gradle:
 ```groovy
-implementation 'com.cvent:sdk:1.2.1'
+implementation 'com.cvent:sdk:1.2.2'
 ```
 
 Maven:
@@ -51,7 +52,7 @@ Maven:
 <dependency>
     <groupId>com.cvent</groupId>
     <artifactId>sdk</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 </dependency>
 ```
 
@@ -1470,7 +1471,7 @@ public class Application {
         // Create a custom HTTP client with hooks
         HTTPClient httpClient = new HTTPClient() {
             private final HTTPClient defaultClient = new SpeakeasyHTTPClient();
-
+            
             @Override
             public HttpResponse<InputStream> send(HttpRequest request) throws IOException, URISyntaxException, InterruptedException {
                 // Add custom header and timeout using Utils.copy()
@@ -1478,7 +1479,7 @@ public class Application {
                     .header("x-custom-header", "custom value")
                     .timeout(Duration.ofSeconds(30))
                     .build();
-
+                    
                 try {
                     HttpResponse<InputStream> response = defaultClient.send(modifiedRequest);
                     // Log successful response
@@ -1650,7 +1651,7 @@ Received response: (GET http://localhost:35123/bearer#global) 200
 Response headers: {access-control-allow-credentials=[true], access-control-allow-origin=[*], connection=[keep-alive], content-length=[50], content-type=[application/json], date=[Wed, 09 Apr 2025 01:43:29 GMT], server=[gunicorn/19.9.0]}
 Response body:
 {
-  "authenticated": true,
+  "authenticated": true, 
   "token": "global"
 }
 ```

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -1470,7 +1470,7 @@ public class Application {
         // Create a custom HTTP client with hooks
         HTTPClient httpClient = new HTTPClient() {
             private final HTTPClient defaultClient = new SpeakeasyHTTPClient();
-                   
+
             @Override
             public HttpResponse<InputStream> send(HttpRequest request) throws IOException, URISyntaxException, InterruptedException {
                 // Add custom header and timeout using Utils.copy()
@@ -1585,6 +1585,8 @@ Both can be overridden globally by calling `SDKHooks.configure()` **before** con
 ```java
 import com.cvent.CventSDK;
 import com.cvent.hooks.SDKHooks;
+import com.cvent.hooks.config.HooksConfiguration;
+import com.cvent.hooks.config.TimeoutHookConfiguration;
 import com.cvent.models.components.SchemeOAuth2ClientCredentials;
 import com.cvent.models.components.Security;
 import java.time.Duration;
@@ -1594,10 +1596,12 @@ public class Application {
     public static void main(String[] args) {
         // Override timeouts before building the SDK.
         // Pass null for either value to keep its default.
-        SDKHooks.configure(
-            Duration.ofSeconds(5),    // connect timeout (default: 10s)
-            Duration.ofSeconds(60)    // call timeout    (default: 30s)
-        );
+        SDKHooks.configure(new HooksConfiguration(
+            new TimeoutHookConfiguration(
+                Duration.ofSeconds(5),    // connect timeout (default: 10s)
+                Duration.ofSeconds(60)    // call timeout    (default: 30s)
+            )
+        ));
 
         CventSDK sdk = CventSDK.builder()
                 .security(Security.builder()
@@ -1617,7 +1621,9 @@ For services with long-running operations (bulk imports, report generation, etc.
 
 ```java
 // Keep the default connect timeout, extend the call timeout to 5 minutes
-SDKHooks.configure(null, Duration.ofMinutes(5));
+SDKHooks.configure(new HooksConfiguration(
+    new TimeoutHookConfiguration(null, Duration.ofMinutes(5))
+));
 ```
 
 > **Note:** `SDKHooks.configure()` sets global JVM-wide state. If your application creates multiple SDK instances with different timeout requirements, call `configure()` again before each `build()` call with the appropriate values.

--- a/packages/java/build-extras.gradle
+++ b/packages/java/build-extras.gradle
@@ -17,6 +17,10 @@ jar {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core:5.19.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.19.0'
+    testImplementation 'org.mock-server:mockserver-junit-jupiter-no-dependencies:5.15.0'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 test {

--- a/packages/java/gradle.properties
+++ b/packages/java/gradle.properties
@@ -1,4 +1,4 @@
 groupId=com.cvent
 artifactId=sdk
-version=1.2.1
+version=1.2.2
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/packages/java/src/main/java/com/cvent/SDKConfiguration.java
+++ b/packages/java/src/main/java/com/cvent/SDKConfiguration.java
@@ -20,7 +20,7 @@ public class SDKConfiguration {
 
     private static final String LANGUAGE = "java";
     public static final String OPENAPI_DOC_VERSION = "ea";
-    public static final String SDK_VERSION = "1.2.1";
+    public static final String SDK_VERSION = "1.2.2";
     public static final String GEN_VERSION = "2.859.2";
     private static final String BASE_PACKAGE = "com.cvent";
     public static final String USER_AGENT = String.format(

--- a/packages/java/src/main/java/com/cvent/hooks/CventRateLimitHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventRateLimitHook.java
@@ -1,5 +1,7 @@
 package com.cvent.hooks;
 
+import com.cvent.hooks.exceptions.QuotaExceededException;
+import com.cvent.hooks.exceptions.ThrottlingException;
 import com.cvent.utils.Hook.AfterError;
 import com.cvent.utils.Hook.AfterErrorContext;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/packages/java/src/main/java/com/cvent/hooks/CventRateLimitHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventRateLimitHook.java
@@ -7,7 +7,6 @@ import com.cvent.utils.Hook.AfterErrorContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;

--- a/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
@@ -7,6 +7,7 @@ import com.cvent.utils.HTTPClient;
 import com.cvent.utils.Hook;
 import com.cvent.utils.SpeakeasyHTTPClient;
 
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 
@@ -17,13 +18,15 @@ import java.time.Duration;
  * <ul>
  *   <li><b>Connect timeout</b> ({@link HttpClient}-level): the maximum time to wait when
  *       establishing a TCP connection to the remote host. Set via
- *       {@link Builder#connectTimeout(Duration)} and applied during the
- *       {@link Hook.SdkInit} phase by replacing the SDK's {@link HTTPClient} with one
- *       backed by a newly built {@link HttpClient}.</li>
+ *       {@link java.net.http.HttpClient.Builder#connectTimeout(Duration)}. Passed as the first
+ *       constructor argument and applied during the {@link Hook.SdkInit} phase by replacing the
+ *       SDK's {@link HTTPClient} with one backed by a newly built {@link HttpClient}.</li>
  *   <li><b>Call timeout</b> ({@link HttpRequest}-level): the maximum time allowed for the
  *       entire request/response cycle — connecting, sending the request, receiving response
- *       headers, and receiving the response body. Set via {@link Builder#callTimeout(Duration)}
- *       and stamped onto every outgoing request in the {@link Hook.BeforeRequest} phase.</li>
+ *       headers, and receiving the response body. Set via
+ *       {@link java.net.http.HttpRequest.Builder#timeout(Duration)}. Passed as the second
+ *       constructor argument and stamped onto every outgoing request in the
+ *       {@link Hook.BeforeRequest} phase.</li>
  * </ul>
  *
  * <h3>Registration in {@code SDKHooks}</h3>

--- a/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
@@ -1,0 +1,184 @@
+package com.cvent.hooks;
+
+import com.cvent.SDKConfiguration;
+import com.cvent.hooks.http.ConnectTimeoutHTTPClient;
+import com.cvent.utils.Helpers;
+import com.cvent.utils.HTTPClient;
+import com.cvent.utils.Hook;
+import com.cvent.utils.SpeakeasyHTTPClient;
+
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A hook that configures connection and call timeouts for all SDK HTTP requests.
+ *
+ * <p>Java's {@link java.net.http.HttpClient} exposes two levels of timeout:
+ * <ul>
+ *   <li><b>Connect timeout</b> ({@link HttpClient}-level): the maximum time to wait when
+ *       establishing a TCP connection to the remote host. Set via
+ *       {@link Builder#connectTimeout(Duration)} and applied during the
+ *       {@link Hook.SdkInit} phase by replacing the SDK's {@link HTTPClient} with one
+ *       backed by a newly built {@link HttpClient}.</li>
+ *   <li><b>Call timeout</b> ({@link HttpRequest}-level): the maximum time allowed for the
+ *       entire request/response cycle — connecting, sending the request, receiving response
+ *       headers, and receiving the response body. Set via {@link Builder#callTimeout(Duration)}
+ *       and stamped onto every outgoing request in the {@link Hook.BeforeRequest} phase.</li>
+ * </ul>
+ *
+ * <p><b>Note on read timeout:</b> Java's built-in HTTP client does not expose a dedicated
+ * <em>read timeout</em> (i.e., maximum time to wait between individual data chunks). The
+ * call timeout is the closest equivalent and bounds the total response-receipt time. If
+ * per-chunk read-timeout semantics are required, you would need to wrap the response body
+ * stream with a custom {@link java.io.InputStream} that enforces a read deadline.
+ *
+ * <h3>Registration in {@code SDKHooks}</h3>
+ * <pre>{@code
+ * CventTimeoutHook timeoutHook = CventTimeoutHook.builder()
+ *     .connectTimeout(Duration.ofSeconds(10))
+ *     .callTimeout(Duration.ofSeconds(60))
+ *     .build();
+ *
+ * hooks.registerSdkInit(timeoutHook);       // applies connect timeout at SDK init
+ * hooks.registerBeforeRequest(timeoutHook); // applies call timeout per request
+ * }</pre>
+ *
+ * <p>For the async hook registry, register the same instance as an async before-request hook
+ * using {@link com.cvent.utils.HookAdapters#toAsync(Hook.BeforeRequest)}:
+ * <pre>{@code
+ * asyncHooks.registerBeforeRequest(HookAdapters.toAsync(timeoutHook));
+ * }</pre>
+ *
+ * @see Hook.SdkInit
+ * @see Hook.BeforeRequest
+ */
+public final class CventTimeoutHook implements Hook.SdkInit, Hook.BeforeRequest {
+
+    private final Duration connectTimeout;
+    private final Duration callTimeout;
+
+    private CventTimeoutHook(Builder builder) {
+        this.connectTimeout = builder.connectTimeout;
+        this.callTimeout = builder.callTimeout;
+    }
+
+    /**
+     * Returns a new {@link Builder} for {@link CventTimeoutHook}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * If a connect timeout is configured <em>and</em> the application has not already supplied a
+     * custom {@link HTTPClient}, replaces the SDK's default {@link SpeakeasyHTTPClient} with one
+     * backed by an {@link java.net.http.HttpClient} built with
+     * {@link java.net.http.HttpClient.Builder#connectTimeout(Duration)}.
+     *
+     * <p>If the application has provided its own {@link HTTPClient} via
+     * {@link com.cvent.CventSDK.Builder#client(HTTPClient)}, that client is left untouched so
+     * that application-level configuration (custom connect timeout, SSL context, executor, etc.)
+     * is preserved. In that case, the application is responsible for configuring its own connect
+     * timeout.
+     *
+     * <p><b>Caveat:</b> If the application explicitly passes a {@link SpeakeasyHTTPClient}
+     * instance (e.g., one with debug logging or custom redacted headers configured) to
+     * {@link com.cvent.CventSDK.Builder#client(HTTPClient)}, the hook will still replace it
+     * because the {@code instanceof SpeakeasyHTTPClient} check cannot distinguish a
+     * caller-configured instance from the SDK default. In that case, the application's
+     * {@link SpeakeasyHTTPClient} settings will be lost. To avoid this, use
+     * {@link ConnectTimeoutHTTPClient} directly or wrap a custom {@link java.net.http.HttpClient}
+     * in a fully custom {@link HTTPClient} implementation.
+     *
+     * <p>This runs once at SDK initialization. The replaced client is used for both synchronous
+     * and asynchronous requests because both paths share the same {@link SDKConfiguration}.
+     *
+     * @param config the current SDK configuration
+     * @return the (possibly modified) SDK configuration
+     */
+    @Override
+    public SDKConfiguration sdkInit(SDKConfiguration config) {
+        if (connectTimeout != null && config.client() instanceof SpeakeasyHTTPClient) {
+            config.setClient(new ConnectTimeoutHTTPClient(connectTimeout));
+        }
+        return config;
+    }
+
+    /**
+     * If a call timeout is configured, stamps it onto the outgoing {@link HttpRequest}.
+     *
+     * <p>The call timeout bounds the entire request/response cycle. If the SDK client's
+     * {@link HTTPClient#send} or {@link HTTPClient#sendAsync} does not complete within this
+     * duration, a {@link java.net.http.HttpTimeoutException} is thrown.
+     *
+     * @param context context for the hook call
+     * @param request the outgoing HTTP request
+     * @return the request with the call timeout applied, or the original request unchanged if no
+     *         call timeout was configured
+     * @throws Exception on error
+     */
+    @Override
+    public HttpRequest beforeRequest(Hook.BeforeRequestContext context, HttpRequest request) throws Exception {
+        if (callTimeout != null && request.timeout().isEmpty()) {
+            return Helpers.copy(request).timeout(callTimeout).build();
+        }
+        return request;
+    }
+
+    /**
+     * Builder for {@link CventTimeoutHook}.
+     */
+    public static final class Builder {
+
+        private Duration connectTimeout;
+        private Duration callTimeout;
+
+        private Builder() {}
+
+        /**
+         * Sets the connect timeout: the maximum time to wait when establishing a TCP connection
+         * to the remote host. Equivalent to Retrofit's {@code connectTimeout}.
+         *
+         * <p>Applied once at SDK initialization via the {@link Hook.SdkInit} phase.
+         *
+         * @param connectTimeout a positive, non-null duration
+         * @return this builder
+         * @throws NullPointerException if {@code connectTimeout} is {@code null}
+         */
+        public Builder connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = Objects.requireNonNull(connectTimeout, "connectTimeout must not be null");
+            return this;
+        }
+
+        /**
+         * Sets the call timeout: the maximum time allowed for the entire request/response cycle.
+         * This covers connecting, sending the request, receiving response headers, and receiving
+         * the response body. Equivalent to Retrofit's {@code callTimeout}.
+         *
+         * <p>Applied per-request via the {@link Hook.BeforeRequest} phase.
+         *
+         * <p><b>Note:</b> Java's HTTP client does not support a dedicated <em>read timeout</em>
+         * separate from the overall call timeout.
+         *
+         * @param callTimeout a positive, non-null duration
+         * @return this builder
+         * @throws NullPointerException if {@code callTimeout} is {@code null}
+         */
+        public Builder callTimeout(Duration callTimeout) {
+            this.callTimeout = Objects.requireNonNull(callTimeout, "callTimeout must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the {@link CventTimeoutHook}.
+         *
+         * @return a new {@link CventTimeoutHook}
+         */
+        public CventTimeoutHook build() {
+            return new CventTimeoutHook(this);
+        }
+    }
+}

--- a/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventTimeoutHook.java
@@ -9,7 +9,6 @@ import com.cvent.utils.SpeakeasyHTTPClient;
 
 import java.net.http.HttpRequest;
 import java.time.Duration;
-import java.util.Objects;
 
 /**
  * A hook that configures connection and call timeouts for all SDK HTTP requests.
@@ -27,18 +26,9 @@ import java.util.Objects;
  *       and stamped onto every outgoing request in the {@link Hook.BeforeRequest} phase.</li>
  * </ul>
  *
- * <p><b>Note on read timeout:</b> Java's built-in HTTP client does not expose a dedicated
- * <em>read timeout</em> (i.e., maximum time to wait between individual data chunks). The
- * call timeout is the closest equivalent and bounds the total response-receipt time. If
- * per-chunk read-timeout semantics are required, you would need to wrap the response body
- * stream with a custom {@link java.io.InputStream} that enforces a read deadline.
- *
  * <h3>Registration in {@code SDKHooks}</h3>
  * <pre>{@code
- * CventTimeoutHook timeoutHook = CventTimeoutHook.builder()
- *     .connectTimeout(Duration.ofSeconds(10))
- *     .callTimeout(Duration.ofSeconds(60))
- *     .build();
+ * CventTimeoutHook timeoutHook = new CventTimeoutHook(Duration.ofSeconds(10), Duration.ofSeconds(60));
  *
  * hooks.registerSdkInit(timeoutHook);       // applies connect timeout at SDK init
  * hooks.registerBeforeRequest(timeoutHook); // applies call timeout per request
@@ -55,21 +45,21 @@ import java.util.Objects;
  */
 public final class CventTimeoutHook implements Hook.SdkInit, Hook.BeforeRequest {
 
+    /**
+     * Maximum time to wait when establishing a TCP connection. If the connection cannot be established within this
+     * time, the request will fail with a timeout error.
+     */
     private final Duration connectTimeout;
-    private final Duration callTimeout;
-
-    private CventTimeoutHook(Builder builder) {
-        this.connectTimeout = builder.connectTimeout;
-        this.callTimeout = builder.callTimeout;
-    }
 
     /**
-     * Returns a new {@link Builder} for {@link CventTimeoutHook}.
-     *
-     * @return a new builder
+     * Maximum time allowed for the entire request/response cycle. If the request/response cycle cannot complete within
+     * this time, the request will fail with a timeout error.
      */
-    public static Builder builder() {
-        return new Builder();
+    private final Duration callTimeout;
+
+    public CventTimeoutHook(Duration connectTimeout, Duration callTimeout) {
+        this.connectTimeout = connectTimeout;
+        this.callTimeout = callTimeout;
     }
 
     /**
@@ -128,57 +118,4 @@ public final class CventTimeoutHook implements Hook.SdkInit, Hook.BeforeRequest 
         return request;
     }
 
-    /**
-     * Builder for {@link CventTimeoutHook}.
-     */
-    public static final class Builder {
-
-        private Duration connectTimeout;
-        private Duration callTimeout;
-
-        private Builder() {}
-
-        /**
-         * Sets the connect timeout: the maximum time to wait when establishing a TCP connection
-         * to the remote host. Equivalent to Retrofit's {@code connectTimeout}.
-         *
-         * <p>Applied once at SDK initialization via the {@link Hook.SdkInit} phase.
-         *
-         * @param connectTimeout a positive, non-null duration
-         * @return this builder
-         * @throws NullPointerException if {@code connectTimeout} is {@code null}
-         */
-        public Builder connectTimeout(Duration connectTimeout) {
-            this.connectTimeout = Objects.requireNonNull(connectTimeout, "connectTimeout must not be null");
-            return this;
-        }
-
-        /**
-         * Sets the call timeout: the maximum time allowed for the entire request/response cycle.
-         * This covers connecting, sending the request, receiving response headers, and receiving
-         * the response body. Equivalent to Retrofit's {@code callTimeout}.
-         *
-         * <p>Applied per-request via the {@link Hook.BeforeRequest} phase.
-         *
-         * <p><b>Note:</b> Java's HTTP client does not support a dedicated <em>read timeout</em>
-         * separate from the overall call timeout.
-         *
-         * @param callTimeout a positive, non-null duration
-         * @return this builder
-         * @throws NullPointerException if {@code callTimeout} is {@code null}
-         */
-        public Builder callTimeout(Duration callTimeout) {
-            this.callTimeout = Objects.requireNonNull(callTimeout, "callTimeout must not be null");
-            return this;
-        }
-
-        /**
-         * Builds the {@link CventTimeoutHook}.
-         *
-         * @return a new {@link CventTimeoutHook}
-         */
-        public CventTimeoutHook build() {
-            return new CventTimeoutHook(this);
-        }
-    }
 }

--- a/packages/java/src/main/java/com/cvent/hooks/CventUserAgentHook.java
+++ b/packages/java/src/main/java/com/cvent/hooks/CventUserAgentHook.java
@@ -2,10 +2,7 @@
 package com.cvent.hooks;
 
 import java.net.http.HttpRequest;
-import java.util.Optional;
-
 import com.cvent.SDKConfiguration;
-import com.cvent.utils.Constants;
 import com.cvent.utils.Helpers;
 import com.cvent.utils.Hook.BeforeRequest;
 import com.cvent.utils.Hook.BeforeRequestContext;

--- a/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
+++ b/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
@@ -1,5 +1,8 @@
 package com.cvent.hooks;
 
+import com.cvent.hooks.config.HooksConfiguration;
+import com.cvent.hooks.config.TimeoutHookConfiguration;
+
 import java.time.Duration;
 
 //
@@ -27,12 +30,12 @@ public final class SDKHooks {
     }
 
     /**
-     * Overrides the default connect and/or call timeouts applied to all SDK instances.
+     * Overrides the default hook settings applied to all SDK instances.
      *
      * <p>Must be called <em>before</em> constructing any {@link com.cvent.CventSDK} instance,
-     * since timeouts are stamped into the SDK at initialization time.
+     * since settings are stamped into the SDK at initialization time.
      *
-     * <p>Pass {@code null} for either value to leave that timeout at its current setting.
+     * <p>Hook configuration entries left unset keep their existing values.
      *
      * <p>Default values:
      * <ul>
@@ -43,18 +46,31 @@ public final class SDKHooks {
      * <p>For services with long-running operations (bulk imports, report generation, etc.),
      * increase the call timeout accordingly:
      * <pre>{@code
-     * SDKHooks.configure(null, Duration.ofMinutes(5));
+     * SDKHooks.configure(new HooksConfiguration(
+     *     new TimeoutHookConfiguration(null, Duration.ofMinutes(5))
+     * ));
      * CventSDK sdk = CventSDK.builder()...build();
      * }</pre>
      *
-     * @param connectTimeout maximum time to wait when establishing a TCP connection;
-     *                       {@code null} keeps the existing value
-     * @param callTimeout    maximum time allowed for the entire request/response cycle;
-     *                       {@code null} keeps the existing value
+     * @param configuration the hook configuration to apply; must not be {@code null}
      */
-    public static void configure(Duration connectTimeout, Duration callTimeout) {
-        if (connectTimeout != null) SDKHooks.connectTimeout = connectTimeout;
-        if (callTimeout != null) SDKHooks.callTimeout = callTimeout;
+    public static void configure(HooksConfiguration configuration) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("configuration must not be null");
+        }
+        TimeoutHookConfiguration timeoutConfig = configuration.getTimeoutHook();
+        if (timeoutConfig != null) {
+            Duration newConnectTimeout = timeoutConfig.getConnectTimeout();
+            Duration newCallTimeout = timeoutConfig.getCallTimeout();
+            if (newConnectTimeout != null) {
+                validatePositiveDuration("connectTimeout", newConnectTimeout);
+                SDKHooks.connectTimeout = newConnectTimeout;
+            }
+            if (newCallTimeout != null) {
+                validatePositiveDuration("callTimeout", newCallTimeout);
+                SDKHooks.callTimeout = newCallTimeout;
+            }
+        }
     }
 
     public static void initialize(com.cvent.utils.Hooks hooks) {
@@ -82,6 +98,17 @@ public final class SDKHooks {
 
         // for more information see
         // https://www.speakeasy.com/docs/additional-features/sdk-hooks
+    }
+
+    /**
+     * Validates that the provided Duration is positive (greater than zero).
+     * @param name the name of the duration parameter (for error messages)
+     * @param duration the duration to validate
+     */
+    private static void validatePositiveDuration(String name, Duration duration) {
+        if (duration.isZero() || duration.isNegative()) {
+            throw new IllegalArgumentException(name + " must be a positive Duration");
+        }
     }
 
 }

--- a/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
+++ b/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
@@ -1,5 +1,7 @@
 package com.cvent.hooks;
 
+import java.time.Duration;
+
 //
 // This file is written once by speakeasy code generation and
 // thereafter will not be overwritten by speakeasy updates. As a
@@ -8,13 +10,63 @@ package com.cvent.hooks;
 
 public final class SDKHooks {
 
+    /**
+     * Maximum time to wait when establishing a TCP connection. If the connection cannot be established within this
+     * time, the request will fail with a timeout error.
+     */
+    private static volatile Duration connectTimeout = Duration.ofSeconds(10);
+
+    /**
+     * Maximum time allowed for the entire request/response cycle. If the request/response cycle cannot complete within
+     * this time, the request will fail with a timeout error.
+     */
+    private static volatile Duration callTimeout = Duration.ofSeconds(30);
+
     private SDKHooks() {
         // prevent instantiation
     }
 
+    /**
+     * Overrides the default connect and/or call timeouts applied to all SDK instances.
+     *
+     * <p>Must be called <em>before</em> constructing any {@link com.cvent.CventSDK} instance,
+     * since timeouts are stamped into the SDK at initialization time.
+     *
+     * <p>Pass {@code null} for either value to leave that timeout at its current setting.
+     *
+     * <p>Default values:
+     * <ul>
+     *   <li><b>Connect timeout:</b> 10 seconds — time to establish a TCP connection</li>
+     *   <li><b>Call timeout:</b> 30 seconds — time for the entire request/response cycle</li>
+     * </ul>
+     *
+     * <p>For services with long-running operations (bulk imports, report generation, etc.),
+     * increase the call timeout accordingly:
+     * <pre>{@code
+     * SDKHooks.configure(null, Duration.ofMinutes(5));
+     * CventSDK sdk = CventSDK.builder()...build();
+     * }</pre>
+     *
+     * @param connectTimeout maximum time to wait when establishing a TCP connection;
+     *                       {@code null} keeps the existing value
+     * @param callTimeout    maximum time allowed for the entire request/response cycle;
+     *                       {@code null} keeps the existing value
+     */
+    public static void configure(Duration connectTimeout, Duration callTimeout) {
+        if (connectTimeout != null) SDKHooks.connectTimeout = connectTimeout;
+        if (callTimeout != null) SDKHooks.callTimeout = callTimeout;
+    }
+
     public static void initialize(com.cvent.utils.Hooks hooks) {
+        CventTimeoutHook timeoutHook = CventTimeoutHook.builder()
+                .connectTimeout(connectTimeout)
+                .callTimeout(callTimeout)
+                .build();
+
         // register synchronous hooks here
+        hooks.registerSdkInit(timeoutHook);
         hooks.registerBeforeRequest(new CventUserAgentHook());
+        hooks.registerBeforeRequest(timeoutHook);
         hooks.registerAfterError(new CventRateLimitHook());
 
         // for more information see
@@ -22,8 +74,15 @@ public final class SDKHooks {
     }
 
     public static void initialize(com.cvent.utils.AsyncHooks asyncHooks) {
+        // connectTimeout is already applied via sdkInit in the synchronous Hooks above,
+        // since both sync and async paths share the same SDKConfiguration and HTTPClient.
+        CventTimeoutHook callTimeoutHook = CventTimeoutHook.builder()
+                .callTimeout(callTimeout)
+                .build();
+
         // Adapt synchronous hooks for async usage
         asyncHooks.registerBeforeRequest(com.cvent.utils.HookAdapters.toAsync(new CventUserAgentHook()));
+        asyncHooks.registerBeforeRequest(com.cvent.utils.HookAdapters.toAsync(callTimeoutHook));
         asyncHooks.registerAfterError(com.cvent.utils.HookAdapters.toAsync(new CventRateLimitHook()));
 
         // for more information see

--- a/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
+++ b/packages/java/src/main/java/com/cvent/hooks/SDKHooks.java
@@ -58,10 +58,7 @@ public final class SDKHooks {
     }
 
     public static void initialize(com.cvent.utils.Hooks hooks) {
-        CventTimeoutHook timeoutHook = CventTimeoutHook.builder()
-                .connectTimeout(connectTimeout)
-                .callTimeout(callTimeout)
-                .build();
+        CventTimeoutHook timeoutHook = new CventTimeoutHook(connectTimeout, callTimeout);
 
         // register synchronous hooks here
         hooks.registerSdkInit(timeoutHook);
@@ -76,13 +73,11 @@ public final class SDKHooks {
     public static void initialize(com.cvent.utils.AsyncHooks asyncHooks) {
         // connectTimeout is already applied via sdkInit in the synchronous Hooks above,
         // since both sync and async paths share the same SDKConfiguration and HTTPClient.
-        CventTimeoutHook callTimeoutHook = CventTimeoutHook.builder()
-                .callTimeout(callTimeout)
-                .build();
+        CventTimeoutHook asyncTimeoutHook = new CventTimeoutHook(null, callTimeout);
 
         // Adapt synchronous hooks for async usage
         asyncHooks.registerBeforeRequest(com.cvent.utils.HookAdapters.toAsync(new CventUserAgentHook()));
-        asyncHooks.registerBeforeRequest(com.cvent.utils.HookAdapters.toAsync(callTimeoutHook));
+        asyncHooks.registerBeforeRequest(com.cvent.utils.HookAdapters.toAsync(asyncTimeoutHook));
         asyncHooks.registerAfterError(com.cvent.utils.HookAdapters.toAsync(new CventRateLimitHook()));
 
         // for more information see

--- a/packages/java/src/main/java/com/cvent/hooks/config/HooksConfiguration.java
+++ b/packages/java/src/main/java/com/cvent/hooks/config/HooksConfiguration.java
@@ -1,0 +1,46 @@
+package com.cvent.hooks.config;
+
+import com.cvent.hooks.SDKHooks;
+import jakarta.annotation.Nullable;
+
+/**
+ * Top-level configuration object for all SDK hooks.
+ *
+ * <p>Pass an instance to {@link SDKHooks#configure(HooksConfiguration)} before constructing any
+ * {@link com.cvent.CventSDK} instance. Hook configuration entries set to {@code null} keep their
+ * existing defaults.
+ *
+ * @see SDKHooks#configure(HooksConfiguration)
+ * @see TimeoutHookConfiguration
+ */
+public final class HooksConfiguration {
+
+    /**
+     * Configuration for the connect and call timeouts.
+     * {@code null} means no timeout changes are requested.
+     */
+    private final TimeoutHookConfiguration timeoutHook;
+
+    /**
+     * Creates a new {@link HooksConfiguration} with no changes to any hook settings.
+     */
+    public HooksConfiguration() {
+        this(null);
+    }
+
+    /**
+     * Creates a new {@link HooksConfiguration}.
+     *
+     * @param timeoutHook timeout hook configuration; {@code null} leaves timeout settings unchanged
+     */
+    public HooksConfiguration(@Nullable TimeoutHookConfiguration timeoutHook) {
+        this.timeoutHook = timeoutHook;
+    }
+
+    /**
+     * @return the timeout hook configuration, or {@code null} if no timeout changes are requested
+     */
+    public TimeoutHookConfiguration getTimeoutHook() {
+        return timeoutHook;
+    }
+}

--- a/packages/java/src/main/java/com/cvent/hooks/config/TimeoutHookConfiguration.java
+++ b/packages/java/src/main/java/com/cvent/hooks/config/TimeoutHookConfiguration.java
@@ -1,0 +1,56 @@
+package com.cvent.hooks.config;
+
+import com.cvent.hooks.SDKHooks;
+import jakarta.annotation.Nullable;
+
+import java.time.Duration;
+
+/**
+ * Configuration for the connect and call timeouts applied to all SDK HTTP requests.
+ *
+ * <p>Pass {@code null} for either value to keep the existing global timeout unchanged.
+ *
+ * @see HooksConfiguration
+ * @see SDKHooks#configure(HooksConfiguration)
+ */
+public final class TimeoutHookConfiguration {
+
+    /**
+     * Maximum time to wait when establishing a TCP connection.
+     * {@code null} means keep the existing value.
+     */
+    private final Duration connectTimeout;
+
+    /**
+     * Maximum time allowed for the entire request/response cycle.
+     * {@code null} means keep the existing value.
+     */
+    private final Duration callTimeout;
+
+    /**
+     * Creates a new {@link TimeoutHookConfiguration}.
+     *
+     * @param connectTimeout maximum time to wait when establishing a TCP connection;
+     *                       {@code null} keeps the existing value
+     * @param callTimeout    maximum time allowed for the entire request/response cycle;
+     *                       {@code null} keeps the existing value
+     */
+    public TimeoutHookConfiguration(@Nullable Duration connectTimeout, @Nullable Duration callTimeout) {
+        this.connectTimeout = connectTimeout;
+        this.callTimeout = callTimeout;
+    }
+
+    /**
+     * @return the connect timeout to apply, or {@code null} to keep the existing value
+     */
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * @return the call timeout to apply, or {@code null} to keep the existing value
+     */
+    public Duration getCallTimeout() {
+        return callTimeout;
+    }
+}

--- a/packages/java/src/main/java/com/cvent/hooks/exceptions/QuotaExceededException.java
+++ b/packages/java/src/main/java/com/cvent/hooks/exceptions/QuotaExceededException.java
@@ -13,7 +13,7 @@ import java.net.http.HttpResponse;
  * making requests and wait for the quota to reset.
  *
  * @see ThrottlingException
- * @see CventRateLimitHook
+ * @see com.cvent.hooks.CventRateLimitHook
  */
 public class QuotaExceededException extends RuntimeException {
 

--- a/packages/java/src/main/java/com/cvent/hooks/exceptions/QuotaExceededException.java
+++ b/packages/java/src/main/java/com/cvent/hooks/exceptions/QuotaExceededException.java
@@ -1,4 +1,4 @@
-package com.cvent.hooks;
+package com.cvent.hooks.exceptions;
 
 import java.net.http.HttpResponse;
 

--- a/packages/java/src/main/java/com/cvent/hooks/exceptions/ThrottlingException.java
+++ b/packages/java/src/main/java/com/cvent/hooks/exceptions/ThrottlingException.java
@@ -12,7 +12,7 @@ import java.net.http.HttpResponse;
  * for each retry up to a maximum of 16 seconds. Stop after 5 attempts.
  *
  * @see QuotaExceededException
- * @see CventRateLimitHook
+ * @see com.cvent.hooks.CventRateLimitHook
  */
 public class ThrottlingException extends RuntimeException {
 

--- a/packages/java/src/main/java/com/cvent/hooks/exceptions/ThrottlingException.java
+++ b/packages/java/src/main/java/com/cvent/hooks/exceptions/ThrottlingException.java
@@ -1,4 +1,4 @@
-package com.cvent.hooks;
+package com.cvent.hooks.exceptions;
 
 import java.net.http.HttpResponse;
 

--- a/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
+++ b/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -39,15 +40,21 @@ import java.util.stream.Collectors;
 public final class ConnectTimeoutHTTPClient implements HTTPClient {
 
     // global debug flag — mirrors SpeakeasyHTTPClient.debugEnabled
-    private static boolean debugEnabled = false;
+    // volatile: setDebugLogging/getDebugLoggingEnabled may be called from different threads
+    private static volatile boolean debugEnabled = false;
 
     // instance-level debug flag — overrides debugEnabled when set
-    private Boolean localDebugEnabled;
+    // volatile: the same client instance may be shared across threads via SDKConfiguration
+    private volatile Boolean localDebugEnabled;
 
     // header names stored uppercase for case-insensitive comparison
-    private static Set<String> redactedHeaders = Set.of("AUTHORIZATION", "X-API-KEY");
+    // AtomicReference (deviation from SpeakeasyHTTPClient): addRedactedHeader uses updateAndGet
+    // for a thread-safe read-modify-write; the referenced Set is always immutable
+    private static final AtomicReference<Set<String>> redactedHeaders =
+            new AtomicReference<>(Set.of("AUTHORIZATION", "X-API-KEY"));
 
-    private static Consumer<? super String> logSink = System.out::println;
+    // volatile: setLogger may be called from one thread while requests are in-flight on others
+    private static volatile Consumer<? super String> logSink = System.out::println;
 
     private final HttpClient httpClient;
 
@@ -103,9 +110,9 @@ public final class ConnectTimeoutHTTPClient implements HTTPClient {
      * @param headerNames header names to redact (case-insensitive)
      */
     public static void setRedactedHeaders(Collection<String> headerNames) {
-        redactedHeaders = headerNames.stream()
+        redactedHeaders.set(headerNames.stream()
                 .map(name -> name.toUpperCase(Locale.ENGLISH))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toUnmodifiableSet()));
     }
 
     /**
@@ -114,9 +121,15 @@ public final class ConnectTimeoutHTTPClient implements HTTPClient {
      * @param headerName header name to redact (case-insensitive)
      */
     public static void addRedactedHeader(String headerName) {
-        Set<String> updated = new HashSet<>(redactedHeaders);
-        updated.add(headerName.toUpperCase(Locale.ENGLISH));
-        redactedHeaders = Set.copyOf(updated);
+        String upperName = headerName.toUpperCase(Locale.ENGLISH);
+        redactedHeaders.updateAndGet(current -> {
+            if (current.contains(upperName)) {
+                return current;
+            }
+            Set<String> updated = new HashSet<>(current);
+            updated.add(upperName);
+            return Set.copyOf(updated);
+        });
     }
 
     /**
@@ -150,7 +163,8 @@ public final class ConnectTimeoutHTTPClient implements HTTPClient {
             request = logRequest(request, true);
         }
         return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofPublisher())
-                .thenApply(response -> new ResponseWithBody<>(response, Blob::from));
+                .thenApply(response -> // TODO: log responses when helper for Blob is setup (mirrors SpeakeasyHTTPClient)
+                new ResponseWithBody<>(response, Blob::from));
     }
 
     // ---- Logging helpers (mirrors SpeakeasyHTTPClient logic) ----
@@ -201,7 +215,7 @@ public final class ConnectTimeoutHTTPClient implements HTTPClient {
         return "{"
                 + headers.map().entrySet().stream()
                         .map(entry -> {
-                            String value = redactedHeaders.contains(
+                            String value = redactedHeaders.get().contains(
                                             entry.getKey().toUpperCase(Locale.ENGLISH))
                                     ? "[******]"
                                     : String.valueOf(entry.getValue());

--- a/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
+++ b/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
@@ -1,0 +1,232 @@
+package com.cvent.hooks.http;
+
+import com.cvent.hooks.CventTimeoutHook;
+import com.cvent.utils.Blob;
+import com.cvent.utils.Helpers;
+import com.cvent.utils.HTTPClient;
+import com.cvent.utils.ResponseWithBody;
+import com.cvent.utils.Utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * An {@link HTTPClient} implementation that routes all requests through an
+ * {@link HttpClient} constructed with a specific connect timeout, while providing
+ * the same debug-logging capabilities as {@code SpeakeasyHTTPClient}.
+ *
+ * <p>When a connect timeout is configured via {@link CventTimeoutHook.Builder#connectTimeout},
+ * this client replaces the default {@code SpeakeasyHTTPClient} in the SDK configuration.
+ * It replicates all {@code SpeakeasyHTTPClient} debug-logging functionality so that
+ * no observability is lost when the client is swapped.
+ *
+ * <h3>Debug logging</h3>
+ * Debug logging is controlled by the same API surface as {@code SpeakeasyHTTPClient}:
+ * <ul>
+ *   <li>{@link #setDebugLogging(boolean)} / {@link #getDebugLoggingEnabled()} — global flag</li>
+ *   <li>{@link #enableDebugLogging(boolean)} / {@link #isDebugLoggingEnabled()} — per-instance flag</li>
+ *   <li>{@link #setRedactedHeaders(Collection)} / {@link #addRedactedHeader(String)} — header redaction</li>
+ *   <li>{@link #setLogger(Consumer)} — custom log sink</li>
+ * </ul>
+ *
+ * <p><strong>Note:</strong> Because this class has its own static debug state, it is
+ * independent of any {@code SpeakeasyHTTPClient} static configuration. If both clients
+ * are active in the same JVM (e.g. in tests), configure debug logging on each separately.
+ *
+ * @see CventTimeoutHook
+ */
+public final class ConnectTimeoutHTTPClient implements HTTPClient {
+
+    // global debug flag — mirrors SpeakeasyHTTPClient.debugEnabled
+    private static boolean debugEnabled = false;
+
+    // instance-level debug flag — overrides debugEnabled when set
+    private Boolean localDebugEnabled;
+
+    // header names stored uppercase for case-insensitive comparison
+    private static Set<String> redactedHeaders = Set.of("AUTHORIZATION", "X-API-KEY");
+
+    private static Consumer<? super String> logSink = System.out::println;
+
+    private final HttpClient httpClient;
+
+    /**
+     * Constructs a new {@link ConnectTimeoutHTTPClient} with the given connect timeout.
+     *
+     * @param connectTimeout the maximum time to wait when establishing a TCP connection;
+     *                       must not be {@code null}
+     */
+    public ConnectTimeoutHTTPClient(Duration connectTimeout) {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(connectTimeout)
+                .build();
+    }
+
+    // ---- Debug configuration ----
+
+    /**
+     * Sets debug logging on or off globally for all {@link ConnectTimeoutHTTPClient} instances.
+     *
+     * <p><strong>WARNING:</strong> This may expose sensitive information in logs and should only
+     * be enabled temporarily for local debugging.
+     *
+     * @param enabled {@code true} to enable debug logging
+     */
+    public static void setDebugLogging(boolean enabled) {
+        debugEnabled = enabled;
+    }
+
+    /**
+     * Returns the global debug-logging flag.
+     *
+     * @return {@code true} if debug logging is globally enabled
+     */
+    public static boolean getDebugLoggingEnabled() {
+        return debugEnabled;
+    }
+
+    @Override
+    public boolean isDebugLoggingEnabled() {
+        return Optional.ofNullable(localDebugEnabled).orElse(debugEnabled);
+    }
+
+    @Override
+    public void enableDebugLogging(boolean enabled) {
+        localDebugEnabled = enabled;
+    }
+
+    /**
+     * Replaces the set of headers whose values are redacted in debug logs.
+     * By default, {@code Authorization} and {@code X-API-Key} are redacted.
+     *
+     * @param headerNames header names to redact (case-insensitive)
+     */
+    public static void setRedactedHeaders(Collection<String> headerNames) {
+        redactedHeaders = headerNames.stream()
+                .map(name -> name.toUpperCase(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Adds a single header to the redaction list.
+     *
+     * @param headerName header name to redact (case-insensitive)
+     */
+    public static void addRedactedHeader(String headerName) {
+        Set<String> updated = new HashSet<>(redactedHeaders);
+        updated.add(headerName.toUpperCase(Locale.ENGLISH));
+        redactedHeaders = Set.copyOf(updated);
+    }
+
+    /**
+     * Replaces the log sink used for debug output. Defaults to {@code System.out::println}.
+     *
+     * @param logger the new log sink
+     */
+    public static void setLogger(Consumer<? super String> logger) {
+        ConnectTimeoutHTTPClient.logSink = logger;
+    }
+
+    // ---- HTTPClient implementation ----
+
+    @Override
+    public HttpResponse<InputStream> send(HttpRequest request)
+            throws IOException, InterruptedException, URISyntaxException {
+        if (isDebugLoggingEnabled()) {
+            request = logRequest(request, true);
+        }
+        HttpResponse<InputStream> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (isDebugLoggingEnabled()) {
+            response = logResponse(response, true);
+        }
+        return response;
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse<Blob>> sendAsync(HttpRequest request) {
+        if (isDebugLoggingEnabled()) {
+            request = logRequest(request, true);
+        }
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofPublisher())
+                .thenApply(response -> new ResponseWithBody<>(response, Blob::from));
+    }
+
+    // ---- Logging helpers (mirrors SpeakeasyHTTPClient logic) ----
+
+    private HttpRequest logRequest(HttpRequest request, boolean logBody) {
+        log("Sending request: " + request);
+        log("Request headers: " + redactHeaders(request.headers()));
+        if (logBody
+                && request.bodyPublisher().isPresent()
+                && request.headers()
+                        .firstValue("Content-Type")
+                        .filter(ct -> ct.equals("application/json") || ct.equals("text/plain"))
+                        .isPresent()) {
+            byte[] body = Helpers.bodyBytes(request);
+            request = Helpers.copy(request)
+                    .method(request.method(), BodyPublishers.ofByteArray(body))
+                    .build();
+            log("Request body:\n" + new String(body, StandardCharsets.UTF_8));
+        }
+        return request;
+    }
+
+    private static HttpResponse<InputStream> logResponse(
+            HttpResponse<InputStream> response, boolean logBody) throws IOException {
+        String contentType =
+                response.headers().firstValue("Content-Type").orElse("application/octet-stream");
+        log("Received response: " + response);
+        log("Response headers: " + redactHeaders(response.headers()));
+
+        // skip caching for streaming responses — they may hang
+        if (contentType.startsWith("text/event-stream")
+                || contentType.startsWith("application/x-ndjson")) {
+            return response;
+        }
+
+        // cache response body so it can be read multiple times (e.g. for logging + processing)
+        response = Utils.cache(response);
+
+        if (logBody
+                && (contentType.startsWith("application/json")
+                        || contentType.startsWith("text/plain"))) {
+            log("Response body:\n" + Utils.toUtf8AndClose(response.body()));
+        }
+        return response;
+    }
+
+    private static String redactHeaders(HttpHeaders headers) {
+        return "{"
+                + headers.map().entrySet().stream()
+                        .map(entry -> {
+                            String value = redactedHeaders.contains(
+                                            entry.getKey().toUpperCase(Locale.ENGLISH))
+                                    ? "[******]"
+                                    : String.valueOf(entry.getValue());
+                            return entry.getKey() + "=" + value;
+                        })
+                        .collect(Collectors.joining(", "))
+                + "}";
+    }
+
+    private static void log(String message) {
+        logSink.accept(message);
+    }
+}

--- a/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
+++ b/packages/java/src/main/java/com/cvent/hooks/http/ConnectTimeoutHTTPClient.java
@@ -27,27 +27,12 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
- * An {@link HTTPClient} implementation that routes all requests through an
- * {@link HttpClient} constructed with a specific connect timeout, while providing
- * the same debug-logging capabilities as {@code SpeakeasyHTTPClient}.
+ * A {@link HTTPClient} that mirrors the SDK's default {@code SpeakeasyHTTPClient} — including
+ * its full debug-logging API — with the addition of a configurable connect timeout.
  *
- * <p>When a connect timeout is configured via {@link CventTimeoutHook.Builder#connectTimeout},
- * this client replaces the default {@code SpeakeasyHTTPClient} in the SDK configuration.
- * It replicates all {@code SpeakeasyHTTPClient} debug-logging functionality so that
- * no observability is lost when the client is swapped.
- *
- * <h3>Debug logging</h3>
- * Debug logging is controlled by the same API surface as {@code SpeakeasyHTTPClient}:
- * <ul>
- *   <li>{@link #setDebugLogging(boolean)} / {@link #getDebugLoggingEnabled()} — global flag</li>
- *   <li>{@link #enableDebugLogging(boolean)} / {@link #isDebugLoggingEnabled()} — per-instance flag</li>
- *   <li>{@link #setRedactedHeaders(Collection)} / {@link #addRedactedHeader(String)} — header redaction</li>
- *   <li>{@link #setLogger(Consumer)} — custom log sink</li>
- * </ul>
- *
- * <p><strong>Note:</strong> Because this class has its own static debug state, it is
- * independent of any {@code SpeakeasyHTTPClient} static configuration. If both clients
- * are active in the same JVM (e.g. in tests), configure debug logging on each separately.
+ * <p>When a connect timeout is configured via {@link CventTimeoutHook}, this client replaces
+ * the default {@code SpeakeasyHTTPClient} in the SDK configuration during
+ * {@link CventTimeoutHook#sdkInit}, so that no observability is lost when the client is swapped.
  *
  * @see CventTimeoutHook
  */

--- a/packages/java/src/test/java/com/cvent/hooks/CventRateLimitHookTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/CventRateLimitHookTest.java
@@ -2,13 +2,10 @@ package com.cvent.hooks;
 
 import com.cvent.hooks.exceptions.QuotaExceededException;
 import com.cvent.hooks.exceptions.ThrottlingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;

--- a/packages/java/src/test/java/com/cvent/hooks/CventRateLimitHookTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/CventRateLimitHookTest.java
@@ -1,5 +1,7 @@
 package com.cvent.hooks;
 
+import com.cvent.hooks.exceptions.QuotaExceededException;
+import com.cvent.hooks.exceptions.ThrottlingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/packages/java/src/test/java/com/cvent/hooks/CventUserAgentHookTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/CventUserAgentHookTest.java
@@ -1,0 +1,28 @@
+package com.cvent.hooks;
+
+import com.cvent.SDKConfiguration;
+import com.cvent.utils.Hook;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.Optional;
+
+public class CventUserAgentHookTest {
+    private final CventUserAgentHook hook = new CventUserAgentHook();
+
+    @Mock
+    private Hook.BeforeRequestContext beforeRequestContext;
+
+    @Test
+    void beforeRequest_overridesUserAgentWithCorrectValue() throws Exception {
+        HttpRequest requestResult = hook.beforeRequest(beforeRequestContext,
+                HttpRequest.newBuilder().uri(new URI("https://test.com")).setHeader("User-Agent", "incorrect").build());
+        // User agent value at time of writing this test "cvent/1.0 Cvent-SDK/0.0.1 (java ea)"
+        assertEquals(requestResult.headers().firstValue("User-Agent"),
+                Optional.of(String.format("cvent/1.0 Cvent-SDK/%s (java %s)", SDKConfiguration.SDK_VERSION,
+                        SDKConfiguration.OPENAPI_DOC_VERSION)));
+    }
+}

--- a/packages/java/src/test/java/com/cvent/hooks/SDKHooksTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/SDKHooksTest.java
@@ -6,6 +6,8 @@ import com.cvent.hooks.http.ConnectTimeoutHTTPClient;
 import com.cvent.utils.Hook;
 import com.cvent.utils.Hook.BeforeRequestContextImpl;
 import com.cvent.utils.Hooks;
+import com.cvent.hooks.config.HooksConfiguration;
+import com.cvent.hooks.config.TimeoutHookConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +27,8 @@ class SDKHooksTest {
     @BeforeEach
     @AfterEach
     void resetToDefaults() {
-        SDKHooks.configure(Duration.ofSeconds(10), Duration.ofSeconds(30));
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(Duration.ofSeconds(10), Duration.ofSeconds(30))));
     }
 
     // ---- Call timeout ----
@@ -42,7 +45,8 @@ class SDKHooksTest {
 
     @Test
     void configure_customCallTimeout_appliedToRequests() throws Exception {
-        SDKHooks.configure(null, Duration.ofSeconds(120));
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(null, Duration.ofSeconds(120))));
 
         Hooks hooks = new Hooks();
         SDKHooks.initialize(hooks);
@@ -54,8 +58,9 @@ class SDKHooksTest {
 
     @Test
     void configure_nullCallTimeout_keepsExistingValue() throws Exception {
-        SDKHooks.configure(null, Duration.ofSeconds(90));
-        SDKHooks.configure(null, null);
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(null, Duration.ofSeconds(90))));
+        SDKHooks.configure(new HooksConfiguration(null));
 
         Hooks hooks = new Hooks();
         SDKHooks.initialize(hooks);
@@ -67,8 +72,10 @@ class SDKHooksTest {
 
     @Test
     void configure_calledMultipleTimes_lastCallWins() throws Exception {
-        SDKHooks.configure(null, Duration.ofSeconds(60));
-        SDKHooks.configure(null, Duration.ofSeconds(180));
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(null, Duration.ofSeconds(60))));
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(null, Duration.ofSeconds(180))));
 
         Hooks hooks = new Hooks();
         SDKHooks.initialize(hooks);
@@ -80,7 +87,8 @@ class SDKHooksTest {
 
     @Test
     void configure_callTimeout_doesNotOverrideRequestWithExistingTimeout() throws Exception {
-        SDKHooks.configure(null, Duration.ofSeconds(120));
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(null, Duration.ofSeconds(120))));
 
         Hooks hooks = new Hooks();
         SDKHooks.initialize(hooks);
@@ -111,7 +119,8 @@ class SDKHooksTest {
 
     @Test
     void configure_customConnectTimeout_replacesDefaultClient() {
-        SDKHooks.configure(Duration.ofSeconds(5), null);
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(Duration.ofSeconds(5), null)));
 
         SDKConfiguration config = new SDKConfiguration();
         Hooks hooks = new Hooks();
@@ -124,8 +133,9 @@ class SDKHooksTest {
 
     @Test
     void configure_nullConnectTimeout_keepsExistingValue() {
-        SDKHooks.configure(Duration.ofSeconds(7), null);
-        SDKHooks.configure(null, null);
+        SDKHooks.configure(new HooksConfiguration(
+                new TimeoutHookConfiguration(Duration.ofSeconds(7), null)));
+        SDKHooks.configure(new HooksConfiguration(null));
 
         SDKConfiguration config = new SDKConfiguration();
         Hooks hooks = new Hooks();

--- a/packages/java/src/test/java/com/cvent/hooks/SDKHooksTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/SDKHooksTest.java
@@ -1,0 +1,154 @@
+package com.cvent.hooks;
+
+import com.cvent.SDKConfiguration;
+import com.cvent.SecuritySource;
+import com.cvent.hooks.http.ConnectTimeoutHTTPClient;
+import com.cvent.utils.Hook;
+import com.cvent.utils.Hook.BeforeRequestContextImpl;
+import com.cvent.utils.Hooks;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SDKHooksTest {
+
+    private static final URI TEST_URI = URI.create("https://api.cvent.com/test");
+
+    @BeforeEach
+    @AfterEach
+    void resetToDefaults() {
+        SDKHooks.configure(Duration.ofSeconds(10), Duration.ofSeconds(30));
+    }
+
+    // ---- Call timeout ----
+
+    @Test
+    void initialize_defaultCallTimeout_is30Seconds() throws Exception {
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        HttpRequest result = hooks.beforeRequest(makeContext(), requestWithoutTimeout());
+
+        assertEquals(Optional.of(Duration.ofSeconds(30)), result.timeout());
+    }
+
+    @Test
+    void configure_customCallTimeout_appliedToRequests() throws Exception {
+        SDKHooks.configure(null, Duration.ofSeconds(120));
+
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        HttpRequest result = hooks.beforeRequest(makeContext(), requestWithoutTimeout());
+
+        assertEquals(Optional.of(Duration.ofSeconds(120)), result.timeout());
+    }
+
+    @Test
+    void configure_nullCallTimeout_keepsExistingValue() throws Exception {
+        SDKHooks.configure(null, Duration.ofSeconds(90));
+        SDKHooks.configure(null, null);
+
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        HttpRequest result = hooks.beforeRequest(makeContext(), requestWithoutTimeout());
+
+        assertEquals(Optional.of(Duration.ofSeconds(90)), result.timeout());
+    }
+
+    @Test
+    void configure_calledMultipleTimes_lastCallWins() throws Exception {
+        SDKHooks.configure(null, Duration.ofSeconds(60));
+        SDKHooks.configure(null, Duration.ofSeconds(180));
+
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        HttpRequest result = hooks.beforeRequest(makeContext(), requestWithoutTimeout());
+
+        assertEquals(Optional.of(Duration.ofSeconds(180)), result.timeout());
+    }
+
+    @Test
+    void configure_callTimeout_doesNotOverrideRequestWithExistingTimeout() throws Exception {
+        SDKHooks.configure(null, Duration.ofSeconds(120));
+
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        HttpRequest original = HttpRequest.newBuilder(TEST_URI)
+                .timeout(Duration.ofSeconds(999))
+                .build();
+
+        HttpRequest result = hooks.beforeRequest(makeContext(), original);
+
+        assertEquals(Optional.of(Duration.ofSeconds(999)), result.timeout(),
+                "a caller-set timeout on the request must not be overwritten by the default");
+    }
+
+    // ---- Connect timeout ----
+
+    @Test
+    void initialize_defaultConnectTimeout_replacesDefaultClient() {
+        SDKConfiguration config = new SDKConfiguration();
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        SDKConfiguration result = hooks.sdkInit(config);
+
+        assertTrue(result.client() instanceof ConnectTimeoutHTTPClient,
+                "sdkInit should replace the default SpeakeasyHTTPClient with ConnectTimeoutHTTPClient");
+    }
+
+    @Test
+    void configure_customConnectTimeout_replacesDefaultClient() {
+        SDKHooks.configure(Duration.ofSeconds(5), null);
+
+        SDKConfiguration config = new SDKConfiguration();
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        SDKConfiguration result = hooks.sdkInit(config);
+
+        assertTrue(result.client() instanceof ConnectTimeoutHTTPClient);
+    }
+
+    @Test
+    void configure_nullConnectTimeout_keepsExistingValue() {
+        SDKHooks.configure(Duration.ofSeconds(7), null);
+        SDKHooks.configure(null, null);
+
+        SDKConfiguration config = new SDKConfiguration();
+        Hooks hooks = new Hooks();
+        SDKHooks.initialize(hooks);
+
+        SDKConfiguration result = hooks.sdkInit(config);
+
+        assertTrue(result.client() instanceof ConnectTimeoutHTTPClient,
+                "connect timeout should still be set after a configure(null, null) call");
+    }
+
+    // ---- Helpers ----
+
+    private static HttpRequest requestWithoutTimeout() {
+        return HttpRequest.newBuilder(TEST_URI).build();
+    }
+
+    private static Hook.BeforeRequestContext makeContext() {
+        return new BeforeRequestContextImpl(
+                new SDKConfiguration(),
+                "https://api.cvent.com",
+                "testOperation",
+                Optional.<List<String>>empty(),
+                Optional.<SecuritySource>empty());
+    }
+}

--- a/packages/java/src/test/java/com/cvent/hooks/http/ConnectTimeoutHTTPClientTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/http/ConnectTimeoutHTTPClientTest.java
@@ -1,0 +1,233 @@
+package com.cvent.hooks.http;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerExtension;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@ExtendWith(MockServerExtension.class)
+class ConnectTimeoutHTTPClientTest {
+
+    @BeforeEach
+    void setUp(MockServerClient mockClient) {
+        mockClient.reset();
+        resetStaticState();
+    }
+
+    @AfterEach
+    void tearDown() {
+        resetStaticState();
+    }
+
+    // ---- Constructor ----
+
+    @Test
+    void constructor_withConnectTimeout_buildsSuccessfully() {
+        assertDoesNotThrow(() -> new ConnectTimeoutHTTPClient(Duration.ofSeconds(10)));
+    }
+
+    // ---- Global debug flag ----
+
+    @Test
+    void getDebugLoggingEnabled_defaultsToFalse() {
+        assertFalse(ConnectTimeoutHTTPClient.getDebugLoggingEnabled());
+    }
+
+    @Test
+    void setDebugLogging_true_enablesGlobalDebugLogging() {
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+        assertTrue(ConnectTimeoutHTTPClient.getDebugLoggingEnabled());
+    }
+
+    @Test
+    void setDebugLogging_false_disablesGlobalDebugLogging() {
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+        ConnectTimeoutHTTPClient.setDebugLogging(false);
+        assertFalse(ConnectTimeoutHTTPClient.getDebugLoggingEnabled());
+    }
+
+    // ---- Instance debug flag ----
+
+    @Test
+    void isDebugLoggingEnabled_withNoInstanceOverride_followsGlobalFlag() {
+        ConnectTimeoutHTTPClient client = new ConnectTimeoutHTTPClient(Duration.ofSeconds(10));
+
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+        assertTrue(client.isDebugLoggingEnabled());
+
+        ConnectTimeoutHTTPClient.setDebugLogging(false);
+        assertFalse(client.isDebugLoggingEnabled());
+    }
+
+    @Test
+    void enableDebugLogging_true_overridesGlobalFalse() {
+        ConnectTimeoutHTTPClient client = new ConnectTimeoutHTTPClient(Duration.ofSeconds(10));
+        ConnectTimeoutHTTPClient.setDebugLogging(false);
+        client.enableDebugLogging(true);
+
+        assertTrue(client.isDebugLoggingEnabled(),
+                "instance flag of true should override global flag of false");
+    }
+
+    @Test
+    void enableDebugLogging_false_overridesGlobalTrue() {
+        ConnectTimeoutHTTPClient client = new ConnectTimeoutHTTPClient(Duration.ofSeconds(10));
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+        client.enableDebugLogging(false);
+
+        assertFalse(client.isDebugLoggingEnabled(),
+                "instance flag of false should override global flag of true");
+    }
+
+    // ---- setLogger ----
+
+    @Test
+    void setLogger_replacesLogSink_logMessagesAreCaptured(MockServerClient mockClient) throws Exception {
+        List<String> captured = new ArrayList<>();
+        ConnectTimeoutHTTPClient.setLogger(captured::add);
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+
+        mockClient.when(request()).respond(response().withStatusCode(200));
+
+        ConnectTimeoutHTTPClient client = new ConnectTimeoutHTTPClient(Duration.ofSeconds(10));
+        client.send(HttpRequest.newBuilder(serverUri(mockClient, "/")).build());
+
+        assertThat(captured).isNotEmpty();
+        assertThat(captured.get(0)).contains("Sending request");
+    }
+
+    // ---- setRedactedHeaders ----
+
+    @Test
+    void setRedactedHeaders_replacesEntireSet_onlyNewHeadersAreRedacted(MockServerClient mockClient) throws Exception {
+        // Replace the default set with only X-Custom-Secret
+        ConnectTimeoutHTTPClient.setRedactedHeaders(List.of("X-Custom-Secret"));
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("Authorization", "open-value")
+                .header("X-Custom-Secret", "hidden-value"));
+
+        String logOutput = String.join("\n", captured);
+        // X-Custom-Secret is in the new set — value must be redacted
+        assertThat(logOutput).doesNotContain("hidden-value");
+        assertThat(logOutput).contains("[******]");
+        // Authorization is NOT in the new set — value must appear in plain text
+        assertThat(logOutput).contains("open-value");
+    }
+
+    @Test
+    void setRedactedHeaders_normalizesToUpperCase_headerIsRedacted(MockServerClient mockClient) throws Exception {
+        // Provide header names in lowercase — they should still match when redacting
+        ConnectTimeoutHTTPClient.setRedactedHeaders(List.of("x-custom-secret"));
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("X-Custom-Secret", "hidden-value"));
+
+        assertThat(String.join("\n", captured)).doesNotContain("hidden-value");
+    }
+
+    // ---- addRedactedHeader ----
+
+    @Test
+    void addRedactedHeader_addsNewHeader_bothDefaultsAndNewHeaderAreRedacted(MockServerClient mockClient) throws Exception {
+        ConnectTimeoutHTTPClient.addRedactedHeader("X-Custom-Secret");
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("X-Custom-Secret", "hidden-new")
+                .header("Authorization", "hidden-default"));
+
+        String logOutput = String.join("\n", captured);
+        assertThat(logOutput).doesNotContain("hidden-new");
+        assertThat(logOutput).doesNotContain("hidden-default");
+    }
+
+    @Test
+    void addRedactedHeader_caseInsensitive_headerIsRedacted(MockServerClient mockClient) throws Exception {
+        // Add in all-lowercase — should still match mixed-case header in the request
+        ConnectTimeoutHTTPClient.addRedactedHeader("x-api-token");
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("X-Api-Token", "secret-value"));
+
+        assertThat(String.join("\n", captured)).doesNotContain("secret-value");
+    }
+
+    @Test
+    void addRedactedHeader_idempotent_repeatedCallsDoNotAffectOtherHeaders(MockServerClient mockClient) throws Exception {
+        // Adding the same header multiple times should not corrupt the set or evict existing headers
+        ConnectTimeoutHTTPClient.addRedactedHeader("Authorization");
+        ConnectTimeoutHTTPClient.addRedactedHeader("Authorization");
+        ConnectTimeoutHTTPClient.addRedactedHeader("AUTHORIZATION");
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("Authorization", "hidden-auth")
+                .header("X-Api-Key", "hidden-key"));
+
+        String logOutput = String.join("\n", captured);
+        assertThat(logOutput).doesNotContain("hidden-auth");
+        assertThat(logOutput).doesNotContain("hidden-key");
+    }
+
+    @Test
+    void addRedactedHeader_existingDefaultHeaderStillRedactedAfterAddingNew(MockServerClient mockClient) throws Exception {
+        ConnectTimeoutHTTPClient.addRedactedHeader("X-New-Secret");
+
+        List<String> captured = captureLogOutput(mockClient, builder -> builder
+                .header("Authorization", "auth-hidden")
+                .header("X-Api-Key", "key-hidden")
+                .header("X-New-Secret", "new-hidden")
+                .header("X-Unredacted", "plaintext"));
+
+        String logOutput = String.join("\n", captured);
+        assertThat(logOutput).doesNotContain("auth-hidden");
+        assertThat(logOutput).doesNotContain("key-hidden");
+        assertThat(logOutput).doesNotContain("new-hidden");
+        assertThat(logOutput).contains("plaintext");
+    }
+
+    // ---- Helpers ----
+
+    @FunctionalInterface
+    private interface RequestCustomizer {
+        HttpRequest.Builder customize(HttpRequest.Builder builder);
+    }
+
+    private List<String> captureLogOutput(MockServerClient mockClient, RequestCustomizer customizer)
+            throws Exception {
+        List<String> captured = new ArrayList<>();
+        ConnectTimeoutHTTPClient.setLogger(captured::add);
+        ConnectTimeoutHTTPClient.setDebugLogging(true);
+
+        mockClient.when(request()).respond(response().withStatusCode(200));
+
+        ConnectTimeoutHTTPClient client = new ConnectTimeoutHTTPClient(Duration.ofSeconds(10));
+        HttpRequest request = customizer.customize(
+                HttpRequest.newBuilder(serverUri(mockClient, "/"))).build();
+        client.send(request);
+
+        return captured;
+    }
+
+    private static URI serverUri(MockServerClient mockClient, String path) {
+        return URI.create("http://localhost:" + mockClient.getPort() + path);
+    }
+
+    private static void resetStaticState() {
+        ConnectTimeoutHTTPClient.setDebugLogging(false);
+        ConnectTimeoutHTTPClient.setRedactedHeaders(List.of("Authorization", "X-Api-Key"));
+        ConnectTimeoutHTTPClient.setLogger(System.out::println);
+    }
+}

--- a/packages/java/src/test/java/com/cvent/hooks/http/CventTimeoutHookTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/http/CventTimeoutHookTest.java
@@ -8,15 +8,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.concurrent.CompletableFuture;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,23 +22,21 @@ class CventTimeoutHookTest {
 
     private static final URI TEST_URI = URI.create("https://api.cvent.com/test");
 
-    // ---- Builder ----
+    // ---- Constructor ----
 
     @Test
-    void builder_connectTimeoutNull_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () ->
-                CventTimeoutHook.builder().connectTimeout(null));
+    void constructor_nullConnectTimeout_isAccepted() {
+        assertDoesNotThrow(() -> new CventTimeoutHook(null, Duration.ofSeconds(30)));
     }
 
     @Test
-    void builder_callTimeoutNull_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () ->
-                CventTimeoutHook.builder().callTimeout(null));
+    void constructor_nullCallTimeout_isAccepted() {
+        assertDoesNotThrow(() -> new CventTimeoutHook(Duration.ofSeconds(10), null));
     }
 
     @Test
-    void builder_noTimeoutsSet_buildsSuccessfully() {
-        assertDoesNotThrow(() -> CventTimeoutHook.builder().build());
+    void constructor_bothNull_isAccepted() {
+        assertDoesNotThrow(() -> new CventTimeoutHook(null, null));
     }
 
     // ---- sdkInit: connect timeout ----
@@ -50,9 +46,7 @@ class CventTimeoutHookTest {
         SDKConfiguration config = new SDKConfiguration();
         HTTPClient originalClient = config.client();
 
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(Duration.ofSeconds(10), null);
 
         SDKConfiguration result = hook.sdkInit(config);
 
@@ -66,9 +60,7 @@ class CventTimeoutHookTest {
         SDKConfiguration config = new SDKConfiguration();
         HTTPClient originalClient = config.client();
 
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .callTimeout(Duration.ofSeconds(30))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(null, Duration.ofSeconds(30));
 
         SDKConfiguration result = hook.sdkInit(config);
 
@@ -80,9 +72,7 @@ class CventTimeoutHookTest {
     @Test
     void sdkInit_returnsTheSameConfigInstance() {
         SDKConfiguration config = new SDKConfiguration();
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .connectTimeout(Duration.ofSeconds(5))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(Duration.ofSeconds(5), null);
 
         SDKConfiguration result = hook.sdkInit(config);
 
@@ -106,9 +96,7 @@ class CventTimeoutHookTest {
         };
         config.setClient(customClient);
 
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(Duration.ofSeconds(10), null);
 
         SDKConfiguration result = hook.sdkInit(config);
 
@@ -121,9 +109,7 @@ class CventTimeoutHookTest {
     @Test
     void beforeRequest_withCallTimeout_stampsTimeoutOnRequest() throws Exception {
         Duration callTimeout = Duration.ofSeconds(45);
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .callTimeout(callTimeout)
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(null, Duration.ofSeconds(45));
 
         HttpRequest original = HttpRequest.newBuilder(TEST_URI).build();
         HttpRequest result = hook.beforeRequest(mockContext(), original);
@@ -134,9 +120,7 @@ class CventTimeoutHookTest {
 
     @Test
     void beforeRequest_withoutCallTimeout_leavesRequestUnchanged() throws Exception {
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(Duration.ofSeconds(10), null);
 
         HttpRequest original = HttpRequest.newBuilder(TEST_URI).build();
         HttpRequest result = hook.beforeRequest(mockContext(), original);
@@ -147,9 +131,7 @@ class CventTimeoutHookTest {
 
     @Test
     void beforeRequest_withCallTimeout_honorsPreviousTimeout() throws Exception {
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .callTimeout(Duration.ofSeconds(20))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(null, Duration.ofSeconds(20));
 
         HttpRequest original = HttpRequest.newBuilder(TEST_URI)
                 .timeout(Duration.ofSeconds(99))
@@ -170,10 +152,7 @@ class CventTimeoutHookTest {
         SDKConfiguration config = new SDKConfiguration();
         HTTPClient originalClient = config.client();
 
-        CventTimeoutHook hook = CventTimeoutHook.builder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .callTimeout(Duration.ofSeconds(60))
-                .build();
+        CventTimeoutHook hook = new CventTimeoutHook(Duration.ofSeconds(10), Duration.ofSeconds(60));
 
         hook.sdkInit(config);
         assertNotSame(originalClient, config.client());

--- a/packages/java/src/test/java/com/cvent/hooks/http/CventTimeoutHookTest.java
+++ b/packages/java/src/test/java/com/cvent/hooks/http/CventTimeoutHookTest.java
@@ -1,0 +1,191 @@
+package com.cvent.hooks.http;
+
+import com.cvent.SDKConfiguration;
+import com.cvent.hooks.CventTimeoutHook;
+import com.cvent.utils.HTTPClient;
+import com.cvent.utils.Hook;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CventTimeoutHookTest {
+
+    private static final URI TEST_URI = URI.create("https://api.cvent.com/test");
+
+    // ---- Builder ----
+
+    @Test
+    void builder_connectTimeoutNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                CventTimeoutHook.builder().connectTimeout(null));
+    }
+
+    @Test
+    void builder_callTimeoutNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                CventTimeoutHook.builder().callTimeout(null));
+    }
+
+    @Test
+    void builder_noTimeoutsSet_buildsSuccessfully() {
+        assertDoesNotThrow(() -> CventTimeoutHook.builder().build());
+    }
+
+    // ---- sdkInit: connect timeout ----
+
+    @Test
+    void sdkInit_withConnectTimeout_replacesHTTPClient() {
+        SDKConfiguration config = new SDKConfiguration();
+        HTTPClient originalClient = config.client();
+
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        SDKConfiguration result = hook.sdkInit(config);
+
+        assertNotNull(result);
+        assertNotSame(originalClient, result.client(),
+                "sdkInit should replace the HTTPClient when a connect timeout is configured");
+    }
+
+    @Test
+    void sdkInit_withoutConnectTimeout_keepsOriginalHTTPClient() {
+        SDKConfiguration config = new SDKConfiguration();
+        HTTPClient originalClient = config.client();
+
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .callTimeout(Duration.ofSeconds(30))
+                .build();
+
+        SDKConfiguration result = hook.sdkInit(config);
+
+        assertNotNull(result);
+        assertSame(originalClient, result.client(),
+                "sdkInit should not replace the HTTPClient when no connect timeout is configured");
+    }
+
+    @Test
+    void sdkInit_returnsTheSameConfigInstance() {
+        SDKConfiguration config = new SDKConfiguration();
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        SDKConfiguration result = hook.sdkInit(config);
+
+        assertSame(config, result, "sdkInit should return the same SDKConfiguration instance");
+    }
+
+    @Test
+    void sdkInit_withConnectTimeoutButCustomClient_doesNotReplaceCustomClient() {
+        SDKConfiguration config = new SDKConfiguration();
+        HTTPClient customClient = new HTTPClient() {
+            @Override
+            public HttpResponse<InputStream> send(HttpRequest request)
+                    throws IOException, URISyntaxException, InterruptedException {
+                throw new UnsupportedOperationException("stub");
+            }
+
+            @Override
+            public CompletableFuture<HttpResponse<com.cvent.utils.Blob>> sendAsync(HttpRequest request) {
+                throw new UnsupportedOperationException("stub");
+            }
+        };
+        config.setClient(customClient);
+
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        SDKConfiguration result = hook.sdkInit(config);
+
+        assertSame(customClient, result.client(),
+                "sdkInit should not replace an application-provided custom HTTPClient");
+    }
+
+    // ---- beforeRequest: call timeout ----
+
+    @Test
+    void beforeRequest_withCallTimeout_stampsTimeoutOnRequest() throws Exception {
+        Duration callTimeout = Duration.ofSeconds(45);
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .callTimeout(callTimeout)
+                .build();
+
+        HttpRequest original = HttpRequest.newBuilder(TEST_URI).build();
+        HttpRequest result = hook.beforeRequest(mockContext(), original);
+
+        assertEquals(Optional.of(callTimeout), result.timeout(),
+                "beforeRequest should stamp the configured call timeout on the request");
+    }
+
+    @Test
+    void beforeRequest_withoutCallTimeout_leavesRequestUnchanged() throws Exception {
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        HttpRequest original = HttpRequest.newBuilder(TEST_URI).build();
+        HttpRequest result = hook.beforeRequest(mockContext(), original);
+
+        assertSame(original, result,
+                "beforeRequest should return the original request when no call timeout is configured");
+    }
+
+    @Test
+    void beforeRequest_withCallTimeout_honorsPreviousTimeout() throws Exception {
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .callTimeout(Duration.ofSeconds(20))
+                .build();
+
+        HttpRequest original = HttpRequest.newBuilder(TEST_URI)
+                .timeout(Duration.ofSeconds(99))
+                .build();
+
+        HttpRequest result = hook.beforeRequest(mockContext(), original);
+
+        assertSame(original, result,
+                "beforeRequest should not modify a request that already has a timeout set");
+        assertEquals(Optional.of(Duration.ofSeconds(99)), result.timeout(),
+                "the caller-set timeout must be preserved");
+    }
+
+    // ---- Both timeouts configured ----
+
+    @Test
+    void bothTimeouts_sdkInitReplacesClientAndBeforeRequestStampsTimeout() throws Exception {
+        SDKConfiguration config = new SDKConfiguration();
+        HTTPClient originalClient = config.client();
+
+        CventTimeoutHook hook = CventTimeoutHook.builder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .callTimeout(Duration.ofSeconds(60))
+                .build();
+
+        hook.sdkInit(config);
+        assertNotSame(originalClient, config.client());
+
+        HttpRequest original = HttpRequest.newBuilder(TEST_URI).build();
+        HttpRequest result = hook.beforeRequest(mockContext(), original);
+        assertEquals(Optional.of(Duration.ofSeconds(60)), result.timeout());
+    }
+
+    // ---- Helpers ----
+
+    private static Hook.BeforeRequestContext mockContext() {
+        return null; // context is not used by CventTimeoutHook.beforeRequest
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ability to configure HTTP connect and call timeouts for the Java SDK. Previously, the SDK used JDK defaults with no way to override them.

## What's New

**Timeout Configuration API** — Call `SDKHooks.configure()` before building the SDK to customize timeouts:

```java
SDKHooks.configure(new HooksConfiguration(
    new TimeoutHookConfiguration(
        Duration.ofSeconds(5),    // connect timeout (default: 10s)
        Duration.ofSeconds(60)    // call timeout    (default: 30s)
    )
));

CventSDK sdk = CventSDK.builder()
        .security(/* ... */)
        .build();
```

Pass `null` for either value to keep the default.

| Timeout | Default | Description |
|---|---|---|
| **Connect** | 10 seconds | Max time to establish a TCP connection |
| **Call** | 30 seconds | Max time for the entire request/response cycle |

## Other Changes

- SDK version bumped to `1.2.2`
- Rate limit exception classes moved to `com.cvent.hooks.exceptions` package (`QuotaExceededException`, `ThrottlingException`)

## Migration Notes

If you import `QuotaExceededException` or `ThrottlingException` directly, update the import path from `com.cvent.hooks` to `com.cvent.hooks.exceptions`.