### PR TITLE
API-5888: Upgraded actions versions to be on Node.js 24 

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -76,7 +76,7 @@ jobs:
       use_sonatype_legacy: ${{ steps.release.outputs.use_sonatype_legacy }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - id: release
         name: Create GitHub Release
@@ -113,10 +113,10 @@ jobs:
         working-directory: ${{ needs.release.outputs.typescript_directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
@@ -197,16 +197,16 @@ jobs:
         working-directory: ${{ needs.release.outputs.java_directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: "corretto"
           java-version: "11"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           gradle-version: "8.14"
 
@@ -284,10 +284,10 @@ jobs:
         working-directory: ${{ needs.release.outputs.csharp_directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@ea9897a6e57642ca932850b656df2880bc7cd2a8
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: "8.x"
 


### PR DESCRIPTION
**API-5888:** Upgraded actions/checkout, actions/setup-node, actions/setup-java, gradle/actions/setup-gradle, and actions/setup-dotnet versions to the latest versions to be on Node.js 24, as the older versions use Node.js 20, which will be EOL by June 16th, 2026, as per [warnings on SDK publish jobs executions](https://github.com/cvent/rest-sdks/actions/runs/24413584066)


### Changes:
- **actions/checkout:**     692973e3d937129bcbf40652eb9f2f61becf3332 `(v4.1.7)` → df4cb1c069e1874edd31b4311f1884172cec0e10 `(v6.0.3)` 
- **actions/setup-node:**          39370e3970a6d050c480ffad4ff0ed4d3fdee5af `(v4.1.0)` → 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e `(v6.4.0)`
- **actions/setup-java:**          c5195efecf7bdfc987ee8bae7a71cb8b11521c00 `(v4.7.1)` → be666c2fcd27ec809703dec50e508c2fdc7f6654 `(v5.2.0)`
- **gradle/actions/setup-gradle:** 017a9effdb900e5b5b2fddfb590a105619dca3c3 `(v4.4.2)` → 50e97c2cd7a37755bbfafc9c5b7cafaece252f6e `(v6.1.0)`
- **actions/setup-dotnet:**        ea9897a6e57642ca932850b656df2880bc7cd2a8 `(v3.3.0)` → 9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 `(v5.3.0)`

The latest version of `actions/checkout` was fetched from its official [GitHub release page.](https://github.com/actions/checkout/releases?page=1). The latest version has the node-version set to 24.

The latest versions of [actions/setup-node](https://github.com/actions/setup-node/releases?page=1), [actions/setup-java](https://github.com/actions/setup-java/releases), [gradle/actions/setup-gradle](https://github.com/gradle/actions/releases) and [actions/setup-dotnet](https://github.com/actions/setup-dotnet/releases?page=1) were fetched from their respective GitHub release pages. These latest versions now internally use the `actions/checkout` version that uses node-version 24. 